### PR TITLE
fix: disable readonly property expectations in tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [v0.13.0]
+- Update to ic-cdk v0.20
+- Update depencenties
+
 ## [v0.12.0]
 - Update to ic-cdk v0.19
 - Update depencenties
@@ -90,6 +94,8 @@
 - Benchmark tests added.
 
 
+[v0.13.0]: https://github.com/wasm-forge/ic-wasi-polyfill/compare/v0.12.0...v0.13.0
+[v0.12.0]: https://github.com/wasm-forge/ic-wasi-polyfill/compare/v0.11.0...v0.12.0
 [v0.11.1]: https://github.com/wasm-forge/ic-wasi-polyfill/compare/v0.11.0...v0.11.1
 [v0.11.0]: https://github.com/wasm-forge/ic-wasi-polyfill/compare/v0.10.0...v0.11.0
 [v0.10.0]: https://github.com/wasm-forge/ic-wasi-polyfill/compare/v0.9.0...v0.10.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,21 +8,19 @@ resolver = "2"
 
 
 [workspace.dependencies]
-# later versions break candid-extract
 candid = "0.10.20"
 ic-cdk = "0.20.0"
 ic-stable-structures = "0.7"
 stable-fs = "0.13.0"
-#stable-fs = {version = "0.13.0", path = "../stable-fs/stable-fs"}
 anyhow = "1.0.102"
 rand = "0.10.1"
 pocket-ic = "13.0.0"
-ic-wasi-polyfill = { path = "ic-wasi-polyfill" }
+ic-wasi-polyfill = { path = "ic-wasi-polyfill"}
 
 serde_bytes = "0.11.17"
 
 cargo_metadata = "0.23.1"
 ic-test = "0.4.0"
 serde = "1.0.219"
-tokio = { version = "1.52", features = ["full"] }
+tokio = { version = "1.52.0", features = ["full"] }
 convert_case = "0.11.0"

--- a/ic-wasi-polyfill/Cargo.toml
+++ b/ic-wasi-polyfill/Cargo.toml
@@ -6,6 +6,7 @@ keywords = ["ic", "wasi", "wasi-polyfill"]
 description = "The project provides polyfill implementation of *wasi_snapshot_preview1* functions using IC System API."
 license = "MIT"
 repository = "https://github.com/wasm-forge/ic-wasi-polyfill"
+readme = "../README.md"
 
 [dependencies]
 stable-fs.workspace = true

--- a/ic-wasi-polyfill/Cargo.toml
+++ b/ic-wasi-polyfill/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ic-wasi-polyfill"
-version = "0.12.0"
+version = "0.13.0"
 edition = "2021"
 keywords = ["ic", "wasi", "wasi-polyfill"]
 description = "The project provides polyfill implementation of *wasi_snapshot_preview1* functions using IC System API."

--- a/ic-wasi-polyfill/src/lib.rs
+++ b/ic-wasi-polyfill/src/lib.rs
@@ -468,7 +468,7 @@ pub unsafe extern "C" fn __ic_custom_path_open(
     #[cfg(feature = "report_wasi_calls")]
     debug_instructions!(
         "__ic_custom_path_open",
-        "parent_fd={parent_fd} dirflags={dirflags} path={file_name} oflags={oflags} fdflags={fdflags}"
+        "parent_fd={parent_fd} dirflags={dirflags} path={file_name} oflags={oflags} fdflags={fdflags} right_base={fs_rights_base} rights_inheriting={fs_rights_inheriting}"
     );
 
     // dirflags contains the information on whether to follow the symlinks,

--- a/ic-wasi-polyfill/tests/fd_tests.rs
+++ b/ic-wasi-polyfill/tests/fd_tests.rs
@@ -4,6 +4,165 @@ use common::libc::{STDERR_FILENO, STDIN_FILENO, STDOUT_FILENO};
 use ic_wasi_polyfill::wasi::{self, Fd};
 use ic_wasi_polyfill::*;
 
+const ROOT_FD: Fd = 3;
+
+#[test]
+fn test_root_fd_filestat_get() {
+    init(&[], &[]);
+
+    let mut stat = wasi::Filestat {
+        dev: 0,
+        ino: 0,
+        filetype: wasi::FILETYPE_UNKNOWN,
+        nlink: 0,
+        size: 0,
+        atim: 0,
+        mtim: 0,
+        ctim: 0,
+    };
+
+    let ret = unsafe { __ic_custom_fd_filestat_get(ROOT_FD, &mut stat as *mut wasi::Filestat) };
+    assert_eq!(ret, 0, "fd_filestat_get on root fd should succeed");
+    assert_eq!(
+        stat.filetype,
+        wasi::FILETYPE_DIRECTORY,
+        "root fd should be a directory"
+    );
+}
+
+#[test]
+fn test_root_path_filestat_get_dot() {
+    init(&[], &[]);
+
+    let path = ".";
+    let mut stat = wasi::Filestat {
+        dev: 0,
+        ino: 0,
+        filetype: wasi::FILETYPE_UNKNOWN,
+        nlink: 0,
+        size: 0,
+        atim: 0,
+        mtim: 0,
+        ctim: 0,
+    };
+
+    let ret = unsafe {
+        __ic_custom_path_filestat_get(
+            ROOT_FD as i32,
+            0,
+            path.as_ptr(),
+            path.len() as i32,
+            &mut stat as *mut wasi::Filestat,
+        )
+    };
+    assert_eq!(ret, 0, "path_filestat_get('.') on root fd should succeed");
+    assert_eq!(
+        stat.filetype,
+        wasi::FILETYPE_DIRECTORY,
+        "'.' should resolve to a directory"
+    );
+}
+
+#[test]
+fn test_root_path_filestat_get_empty() {
+    // Some WASI runtimes pass an empty path when the target is the dir itself.
+    init(&[], &[]);
+
+    let path = "";
+    let mut stat = wasi::Filestat {
+        dev: 0,
+        ino: 0,
+        filetype: wasi::FILETYPE_UNKNOWN,
+        nlink: 0,
+        size: 0,
+        atim: 0,
+        mtim: 0,
+        ctim: 0,
+    };
+
+    let ret = unsafe {
+        __ic_custom_path_filestat_get(
+            ROOT_FD as i32,
+            0,
+            path.as_ptr(),
+            path.len() as i32,
+            &mut stat as *mut wasi::Filestat,
+        )
+    };
+    assert_eq!(ret, 0, "path_filestat_get('') on root fd should succeed");
+    assert_eq!(
+        stat.filetype,
+        wasi::FILETYPE_DIRECTORY,
+        "empty path should resolve to a directory"
+    );
+}
+
+#[test]
+fn test_root_path_open_dot() {
+    // Verifies that path_open(".") on the root fd succeeds and returns a dir fd.
+    init(&[], &[]);
+
+    let path = ".";
+    let mut dir_fd: Fd = 0;
+
+    let ret = unsafe {
+        __ic_custom_path_open(
+            ROOT_FD,
+            0,
+            path.as_ptr(),
+            path.len() as i32,
+            wasi::OFLAGS_DIRECTORY as i32,
+            common::DEFAULT_RIGHTS,
+            common::DEFAULT_RIGHTS,
+            0,
+            &mut dir_fd as *mut Fd,
+        )
+    };
+    assert_eq!(ret, 0, "path_open('.') should succeed");
+    assert!(dir_fd > 3, "opened fd should be above the pre-opened range");
+
+    // Confirm the opened fd is a directory with write rights.
+    let mut fdstat = wasi::Fdstat {
+        fs_filetype: wasi::FILETYPE_UNKNOWN,
+        fs_flags: 0,
+        fs_rights_base: 0,
+        fs_rights_inheriting: 0,
+    };
+    let ret = unsafe { __ic_custom_fd_fdstat_get(dir_fd, &mut fdstat as *mut wasi::Fdstat) };
+    assert_eq!(ret, 0, "fd_fdstat_get on opened '.' fd should succeed");
+    assert_eq!(
+        fdstat.fs_filetype,
+        wasi::FILETYPE_DIRECTORY,
+        "opened '.' should be a directory"
+    );
+    assert!(
+        fdstat.fs_rights_base & wasi::RIGHTS_FD_WRITE != 0,
+        "root dir opened via '.' should have write rights (not readonly)"
+    );
+
+    __ic_custom_fd_close(dir_fd);
+}
+
+#[test]
+fn test_root_fd_fdstat_has_write_rights() {
+    // The pre-opened root fd=3 itself should carry write rights.
+    init(&[], &[]);
+
+    let mut fdstat = wasi::Fdstat {
+        fs_filetype: wasi::FILETYPE_UNKNOWN,
+        fs_flags: 0,
+        fs_rights_base: 0,
+        fs_rights_inheriting: 0,
+    };
+
+    let ret = unsafe { __ic_custom_fd_fdstat_get(ROOT_FD, &mut fdstat as *mut wasi::Fdstat) };
+    assert_eq!(ret, 0, "fd_fdstat_get on root fd should succeed");
+    assert!(
+        fdstat.fs_rights_base & wasi::RIGHTS_FD_WRITE != 0,
+        "root fd should have write rights (not readonly)"
+    );
+}
+
 #[test]
 fn test_fd_prestat_init_fd_prestat_dir_name() {
     init(&[], &[]);

--- a/integration-tests/src/tests/fuzz_tests.rs
+++ b/integration-tests/src/tests/fuzz_tests.rs
@@ -25,7 +25,7 @@ async fn test_fs_durability() {
     let env = test_setup::setup(IcpTest::new().await).await;
 
     let backend = env.fs_tests_backend;
-
+    
     let _c = backend.do_fs_test().call().await;
 
     // re-deploy
@@ -47,6 +47,7 @@ async fn test_fs_durability() {
 
     let expected_log_ =
         std::fs::read_to_string("../target/release/playground/playground/log.txt").unwrap();
+
     let expected_log = expected_log_.trim();
 
     if computed != expected {

--- a/integration-tests/src/tests/fuzz_tests.rs
+++ b/integration-tests/src/tests/fuzz_tests.rs
@@ -25,7 +25,7 @@ async fn test_fs_durability() {
     let env = test_setup::setup(IcpTest::new().await).await;
 
     let backend = env.fs_tests_backend;
-    
+
     let _c = backend.do_fs_test().call().await;
 
     // re-deploy

--- a/integration-tests/src/tests/integration_tests.rs
+++ b/integration-tests/src/tests/integration_tests.rs
@@ -407,7 +407,7 @@ async fn created_dir_is_writable() {
 
     let result = env
         .canister_initial_backend
-        .check_new_dir_is_writable("/usr/tmp".to_string())
+        .check_new_dir_is_writable("tmp".to_string())
         .call()
         .await;
 

--- a/test_canisters/canister_initial/new_dir_writable.sh
+++ b/test_canisters/canister_initial/new_dir_writable.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+dfx canister call canister_initial_backend check_new_dir_is_writable '("tmp")'

--- a/test_canisters/canister_initial/src/canister_initial_backend/src/lib.rs
+++ b/test_canisters/canister_initial/src/canister_initial_backend/src/lib.rs
@@ -687,29 +687,21 @@ pub fn create_files(path: String, count: usize) -> u64 {
 pub fn check_new_dir_is_writable(dirname: String) -> String {
     std::fs::create_dir(&dirname).unwrap();
 
-    let md = fs::metadata(&dirname).unwrap();
+    let test_file = format!("{}/test.txt", dirname);
 
-    let permissions = md.permissions();
-    let readonly = permissions.readonly();
-
-    if readonly {
-        "Is readonly".to_string()
-    } else {
-        "Is writable".to_string()
+    match std::fs::write(&test_file, b"hello") {
+        Ok(_) => "Is writable".to_string(),
+        Err(_e) => "Is readonly".to_string(),
     }
 }
 
 #[ic_cdk::update]
 pub fn check_dir_is_writable(dirname: String) -> String {
-    let md = fs::metadata(&dirname).unwrap();
+    let test_file = format!("{}/test.txt", dirname);
 
-    let permissions = md.permissions();
-    let readonly = permissions.readonly();
-
-    if readonly {
-        "Is readonly".to_string()
-    } else {
-        "Is writable".to_string()
+    match std::fs::write(&test_file, b"hello") {
+        Ok(_) => "Is writable".to_string(),
+        Err(_e) => "Is readonly".to_string(),
     }
 }
 
@@ -717,15 +709,11 @@ pub fn check_dir_is_writable(dirname: String) -> String {
 pub fn check_new_file_is_writable(file: String) -> String {
     std::fs::File::create(&file).unwrap();
 
-    let md = fs::metadata(&file).unwrap();
+    let test_file = format!("{}", file);
 
-    let permissions = md.permissions();
-    let readonly = permissions.readonly();
-
-    if readonly {
-        "Is readonly".to_string()
-    } else {
-        "Is writable".to_string()
+    match std::fs::write(&test_file, b"hello") {
+        Ok(_) => "Is writable".to_string(),
+        Err(_e) => "Is readonly".to_string(),
     }
 }
 

--- a/test_canisters/canister_initial/src/canister_initial_backend/src/lib.rs
+++ b/test_canisters/canister_initial/src/canister_initial_backend/src/lib.rs
@@ -709,7 +709,7 @@ pub fn check_dir_is_writable(dirname: String) -> String {
 pub fn check_new_file_is_writable(file: String) -> String {
     std::fs::File::create(&file).unwrap();
 
-    let test_file = format!("{}", file);
+    let test_file = file.to_string();
 
     match std::fs::write(&test_file, b"hello") {
         Ok(_) => "Is writable".to_string(),

--- a/test_canisters/canister_upgraded/src/canister_upgraded_backend/src/lib.rs
+++ b/test_canisters/canister_upgraded/src/canister_upgraded_backend/src/lib.rs
@@ -687,29 +687,21 @@ pub fn create_files(path: String, count: usize) -> u64 {
 pub fn check_new_dir_is_writable(dirname: String) -> String {
     std::fs::create_dir(&dirname).unwrap();
 
-    let md = fs::metadata(&dirname).unwrap();
+    let test_file = format!("{}/test.txt", dirname);
 
-    let permissions = md.permissions();
-    let readonly = permissions.readonly();
-
-    if readonly {
-        "Is readonly".to_string()
-    } else {
-        "Is writable".to_string()
+    match std::fs::write(&test_file, b"hello") {
+        Ok(_) => "Is writable".to_string(),
+        Err(_e) => "Is readonly".to_string(),
     }
 }
 
 #[ic_cdk::update]
 pub fn check_dir_is_writable(dirname: String) -> String {
-    let md = fs::metadata(&dirname).unwrap();
+    let test_file = format!("{}/test.txt", dirname);
 
-    let permissions = md.permissions();
-    let readonly = permissions.readonly();
-
-    if readonly {
-        "Is readonly".to_string()
-    } else {
-        "Is writable".to_string()
+    match std::fs::write(&test_file, b"hello") {
+        Ok(_) => "Is writable".to_string(),
+        Err(_e) => "Is readonly".to_string(),
     }
 }
 
@@ -717,15 +709,11 @@ pub fn check_dir_is_writable(dirname: String) -> String {
 pub fn check_new_file_is_writable(file: String) -> String {
     std::fs::File::create(&file).unwrap();
 
-    let md = fs::metadata(&file).unwrap();
+    let test_file = format!("{}", file);
 
-    let permissions = md.permissions();
-    let readonly = permissions.readonly();
-
-    if readonly {
-        "Is readonly".to_string()
-    } else {
-        "Is writable".to_string()
+    match std::fs::write(&test_file, b"hello") {
+        Ok(_) => "Is writable".to_string(),
+        Err(_e) => "Is readonly".to_string(),
     }
 }
 

--- a/test_canisters/canister_upgraded/src/canister_upgraded_backend/src/lib.rs
+++ b/test_canisters/canister_upgraded/src/canister_upgraded_backend/src/lib.rs
@@ -709,7 +709,7 @@ pub fn check_dir_is_writable(dirname: String) -> String {
 pub fn check_new_file_is_writable(file: String) -> String {
     std::fs::File::create(&file).unwrap();
 
-    let test_file = format!("{}", file);
+    let test_file = file.to_string();
 
     match std::fs::write(&test_file, b"hello") {
         Ok(_) => "Is writable".to_string(),

--- a/test_canisters/fs_tests/src/fs_tests_backend/src/canister.rs
+++ b/test_canisters/fs_tests/src/fs_tests_backend/src/canister.rs
@@ -12,7 +12,7 @@ fn greet(name: String) -> String {
 use std::{
     cell::RefCell,
     collections::BTreeMap,
-    fs::{self, FileType, Permissions},
+    fs::{self, FileType},
     io::{Seek, SeekFrom},
     path::PathBuf,
 };
@@ -274,7 +274,18 @@ pub fn generate_random_fs(seed: u64, steps: u64, max_depth: u64) -> u64 {
 
 #[ic_cdk::query]
 pub fn get_log() -> String {
-    std::fs::read_to_string("./log.txt").unwrap()
+    use std::fs::File;
+    use std::io::Read;
+
+    const MAX_SIZE: usize = 2_500_000; // ~2.5 MB
+
+    let mut file = File::open("./log.txt").unwrap();
+    let mut buffer = vec![0; MAX_SIZE];
+
+    let bytes_read = file.read(&mut buffer).unwrap();
+    buffer.truncate(bytes_read);
+
+    String::from_utf8_lossy(&buffer).to_string()
 }
 
 fn get_random_file(
@@ -372,9 +383,6 @@ fn rename_opened_file(opened_files: &mut BTreeMap<String, File>, from: &str, to:
     }
 }
 
-fn permissions_str(per: Permissions) -> String {
-    format!("permissions: readonly = {}", per.readonly())
-}
 
 fn file_type_str(ftype: FileType) -> String {
     format!(
@@ -630,13 +638,6 @@ fn generate_random_file_structure(
 
                 let meta = fs::metadata(&path)?;
 
-                save.write_all(
-                    format!(
-                        "{path:?}.metadata.{:?}\n",
-                        permissions_str(meta.permissions())
-                    )
-                    .as_bytes(),
-                )?;
 
                 save.write_all(
                     format!(

--- a/test_canisters/fs_tests/src/fs_tests_backend/src/canister.rs
+++ b/test_canisters/fs_tests/src/fs_tests_backend/src/canister.rs
@@ -383,7 +383,6 @@ fn rename_opened_file(opened_files: &mut BTreeMap<String, File>, from: &str, to:
     }
 }
 
-
 fn file_type_str(ftype: FileType) -> String {
     format!(
         "file_type: is_file = {}, is_dir = {}, is_symlink = {}",
@@ -637,7 +636,6 @@ fn generate_random_file_structure(
                 let path = get_random_file(parent_path, current_op, opened_files)?;
 
                 let meta = fs::metadata(&path)?;
-
 
                 save.write_all(
                     format!(


### PR DESCRIPTION
- fix broken tests related to the readonly property of files
- we don't rely on the property, as it is also now the behaviour in the wasmtime runtime environment